### PR TITLE
Allow use of the test_helper.exs pattern

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,3 +44,21 @@ jobs:
         run: |
           ! bazelisk test //:failing_test
           ! bazelisk test //:broken_test
+  examples-basic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CHECKOUT REPOSITORY
+        uses: actions/checkout@v4
+      - name: SETUP ERLANG/ELIXIR
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: 26
+          elixir-version: 1.15
+      - name: CONFIGURE
+        working-directory: examples/basic
+        run: |
+          echo "build --color=yes" >> .bazelrc
+      - name: BUILD & TEST
+        working-directory: examples/basic
+        run: |
+          bazelisk test //...

--- a/examples/basic/BUILD.bazel
+++ b/examples/basic/BUILD.bazel
@@ -24,3 +24,20 @@ ex_unit_test(
         "ERL_COMPILER_OPTIONS": "deterministic",
     },
 )
+
+ex_unit_test(
+    name = "helped_test",
+    srcs = [
+        "test/helped_test.exs",
+    ],
+    data = [
+        "test/test_helper.exs",
+    ],
+    env = {
+        "ERL_COMPILER_OPTIONS": "deterministic",
+    },
+    elixir_opts = [
+        "-r",
+        "test/test_helper.exs",
+    ],
+)

--- a/examples/basic/test/helped_test.exs
+++ b/examples/basic/test/helped_test.exs
@@ -1,0 +1,8 @@
+defmodule AssertionTest do
+  use ExUnit.Case, async: true
+  import TestHelper
+
+  test "the truth" do
+    assert the_truth()
+  end
+end

--- a/examples/basic/test/test_helper.exs
+++ b/examples/basic/test/test_helper.exs
@@ -1,0 +1,11 @@
+ExUnit.configure(
+  seed: 0
+)
+
+ExUnit.start()
+
+defmodule TestHelper do
+  def the_truth do
+    true
+  end
+end

--- a/private/ex_unit_test.bzl
+++ b/private/ex_unit_test.bzl
@@ -19,12 +19,12 @@ def _package_relative_path(ctx, p):
     return p.removeprefix(ctx.label.package + "/")
 
 def _impl(ctx):
-    copy_srcs_commands = [
+    copy_srcs_and_data_commands = [
         "mkdir -p $(dirname {dst}) && cp {src} {dst}".format(
             src = s.path,
             dst = path_join("${TEST_UNDECLARED_OUTPUTS_DIR}", _package_relative_path(ctx, s.path)),
         )
-        for s in ctx.files.srcs
+        for s in ctx.files.srcs + ctx.files.data
     ]
 
     erl_libs_dir = ctx.label.name + "_deps"
@@ -53,7 +53,7 @@ def _impl(ctx):
 #!/usr/bin/env bash
 set -eo pipefail
 
-{copy_srcs_commands}
+{copy_srcs_and_data_commands}
 
 export ERL_LIBS=$TEST_SRCDIR/$TEST_WORKSPACE/{erl_libs_path}
 
@@ -72,7 +72,7 @@ $TEST_SRCDIR/$TEST_WORKSPACE/{elixir} \\
 set +x
 tail -n 4 test.log | grep --silent "0 failure" && rm test.log
 """.format(
-            copy_srcs_commands = "\n".join(copy_srcs_commands),
+            copy_srcs_and_data_commands = "\n".join(copy_srcs_and_data_commands),
             erl_libs_path = erl_libs_path,
             env = env,
             setup = ctx.attr.setup,

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -26,6 +26,23 @@ ex_unit_test(
 )
 
 ex_unit_test(
+    name = "helped_test",
+    srcs = [
+        "test/helped_test.exs",
+    ],
+    data = [
+        "test/test_helper.exs",
+    ],
+    env = {
+        "ERL_COMPILER_OPTIONS": "deterministic",
+    },
+    elixir_opts = [
+        "-r",
+        "test/test_helper.exs",
+    ],
+)
+
+ex_unit_test(
     name = "failing_test",
     srcs = [
         "test/failing_test.exs",

--- a/test/test/helped_test.exs
+++ b/test/test/helped_test.exs
@@ -1,0 +1,8 @@
+defmodule AssertionTest do
+  use ExUnit.Case, async: true
+  import TestHelper
+
+  test "the truth" do
+    assert the_truth()
+  end
+end

--- a/test/test/test_helper.exs
+++ b/test/test/test_helper.exs
@@ -1,0 +1,11 @@
+ExUnit.configure(
+  seed: 0
+)
+
+ExUnit.start()
+
+defmodule TestHelper do
+  def the_truth do
+    true
+  end
+end


### PR DESCRIPTION
- files passed as data to ex_unit_test are available when the test is executed